### PR TITLE
Fix for passwords containing spaces

### DIFF
--- a/sh/getpwd.sh
+++ b/sh/getpwd.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 PWD=`security find-generic-password -wa $1`
-printf "$PWD"
-#printf %q "$PWD" #Escaped PWD!
+
+# for mount_smbfs, spaces in passwords need to be escaped as %20
+printf "%s" `echo ${PWD// /%20}`

--- a/sh/getsetpwd.sh
+++ b/sh/getsetpwd.sh
@@ -12,5 +12,5 @@ then
     echo -n Password:  
     read -s password
 
-    security add-generic-password -a ${account} -s ${service} -w ${password}
+    security add-generic-password -a "${account}" -s "${service}" -w "${password}"
 fi

--- a/sh/setpwd.sh
+++ b/sh/setpwd.sh
@@ -6,8 +6,8 @@ read account
 echo -n Service: 
 read service
 
-echo -n Password:  
+echo -n Password: 
 read -s password
-echo "Got pwd: $password"
+echo "$password"
 
-security add-generic-password -a ${account} -s ${service} -w ${password}
+security add-generic-password -a "${account}" -s "${service}" -w "${password}"


### PR DESCRIPTION
I've added the necessary changes, as outlined by the two issues I've opened - #2, #3 - where passwords with spaces fail.
